### PR TITLE
Fix: replaced all involved gemini-2.5 versions with 1.5

### DIFF
--- a/config/ai_council.yaml
+++ b/config/ai_council.yaml
@@ -37,8 +37,8 @@ models:
     max_context_length: 131072
     timeout_seconds: 45.0
 
-  # Google Gemini 2.5 Flash - ENABLED (Working!)
-  gemini-2.5-flash:
+  # Google Gemini 1.5 Flash - ENABLED (Working!)
+  gemini-1.5-flash:
     enabled: true
     provider: google
     api_key_env: GOOGLE_API_KEY


### PR DESCRIPTION
Fix- Updated invalid Gemini model versions to 1.5

​Description-
​I have updated the configuration file to replace the invalid gemini-2.5-flash version with the correct gemini-1.5-flash. This change ensures the project uses a valid Google AI model and prevents potential API connection errors.

I am submitting this pull request as part of OSCG'26 contributor.