### PR TITLE
fix(startup): serve frontend via http.server

### DIFF
--- a/web_app/start.bat
+++ b/web_app/start.bat
@@ -38,7 +38,9 @@ REM Start frontend
 echo [3/3] Opening frontend...
 timeout /t 2 /nobreak >nul
 start http://localhost:8000/api/status
-start frontend\index.html
+start "AI Council Frontend Server" cmd /k "cd frontend && python -m http.server 8080"
+timeout /t 2 /nobreak >nul
+start http://localhost:8080/
 
 echo.
 echo ========================================
@@ -46,7 +48,7 @@ echo   AI Council is running!
 echo ========================================
 echo.
 echo Backend API: http://localhost:8000
-echo Frontend: Open frontend\index.html in your browser
+echo Frontend: http://localhost:8080
 echo.
 echo Press Ctrl+C in the backend window to stop
 echo.

--- a/web_app/start.sh
+++ b/web_app/start.sh
@@ -40,12 +40,21 @@ sleep 3
 
 # Start frontend
 echo "[3/3] Opening frontend..."
+# Start frontend server
+echo "[3/3] Starting frontend server..."
+cd frontend
+python3 -m http.server 8080 &
+FRONTEND_PID=$!
+cd ..
+
+# Open in browser
+sleep 2
 if command -v xdg-open > /dev/null; then
-    xdg-open frontend/index.html
+    xdg-open http://localhost:8080/
 elif command -v open > /dev/null; then
-    open frontend/index.html
+    open http://localhost:8080/
 else
-    echo "Please open frontend/index.html in your browser"
+    echo "Please open http://localhost:8080/ in your browser"
 fi
 
 echo ""
@@ -54,11 +63,11 @@ echo "  AI Council is running!"
 echo "========================================"
 echo ""
 echo "Backend API: http://localhost:8000"
-echo "Frontend: frontend/index.html"
+echo "Frontend: http://localhost:8080"
 echo ""
 echo "Press Ctrl+C to stop"
 echo ""
 
 # Wait for Ctrl+C
-trap "kill $BACKEND_PID; exit" INT
+trap "kill $BACKEND_PID $FRONTEND_PID; exit" INT
 wait $BACKEND_PID


### PR DESCRIPTION
issue:#51

**For start.bat (Windows):**

- Replaced the command that opened the index HTML file directly with a command to start a Python HTTP server on port 8080.
- Added a timeout to allow the server time to initialize.
- Updated the browser launch command to open the localhost URL instead of the file path.
- Updated the console output text to show the new HTTP address.

**For start.sh (Linux/macOS):**


- Added a background process to start the Python HTTP server on port 8080 inside the frontend directory.
- Captured the Process ID of the new frontend server.
- Updated the browser open command to use the localhost URL.
- Modified the cleanup trap to ensure the frontend server is stopped when the script exits.
- Updated the console output text to show the new HTTP address.