### PR TITLE
Fix  #131 - [DevOps] Add Automated Release Pipeline for PyPI Publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,54 @@
+name: Publish to PyPI
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: publish-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Build and publish package
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.8 (supports 3.8+)
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.8"
+          cache: "pip"
+
+      - name: Install build and publishing tools
+        run: |
+          set -euxo pipefail
+          python -m pip install --upgrade pip
+          python -m pip install --upgrade build twine
+
+      - name: Build source and wheel distributions
+        run: |
+          set -euxo pipefail
+          python -m build
+
+      - name: Validate package distributions
+        run: |
+          set -euxo pipefail
+          python -m twine check --strict dist/*
+
+      - name: Publish package to PyPI
+        env:
+          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        run: |
+          set -euxo pipefail
+          test -n "${TWINE_USERNAME}"
+          test -n "${TWINE_PASSWORD}"
+          python -m twine upload --non-interactive dist/*


### PR DESCRIPTION
Summary
This PR introduces an automated release pipeline that builds and publishes the AI Council Orchestrator package to PyPI.

Changes
* Added GitHub Actions workflow for automated releases
* Implemented package build using Python build module
* Integrated PyPI publishing via twine
* Secure authentication using GitHub secrets

Benefits
* Eliminates manual release process
* Ensures consistent package publishing
* Improves DevOps automation

OSCG 2026'

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Automated package publishing to PyPI is now configured, enabling reliable distribution of releases through GitHub Actions on version tags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->