### PR TITLE
Fixes Remove sys.path manipulation in web_app/backend/main.py #156

### DIFF
--- a/web_app/backend/main.py
+++ b/web_app/backend/main.py
@@ -23,10 +23,6 @@ from slowapi.errors import RateLimitExceeded
 from slowapi.middleware import SlowAPIMiddleware
 from slowapi.util import get_remote_address
 from starlette.middleware.base import BaseHTTPMiddleware
-
-# Add ai_council to path
-sys.path.insert(0, str(Path(__file__).parent.parent.parent))
-
 from ai_council.core.models import ExecutionMode
 from ai_council.main import AICouncil
 


### PR DESCRIPTION
FIXES #156 

---

## Description:
This PR addresses issue #156
 by removing the manual sys.path.insert line in web_app/backend/main.py.

Problem:

`sys.path.insert(0, str(Path(__file__).parent.parent.parent))`
Manually prepends the project root to `Python’s import path.`
Can cause import shadowing of standard library or third-party modules.
Is redundant, because` pip install -e ../..` already makes ai_council importable.
Is fragile: moving files breaks the relative path calculation.

## Solution:

Remove the sys.path.insert line.
Rely on editable installation for imports.
No functionality changes — backend imports continue to work.

## Affected File:

`web_app/backend/main.py`

## Testing Done:

Verified import works:
`python -c "from ai_council.main import AICouncil; print('AICouncil imported successfully')"`
Backend runs successfully without sys.path modification.

@shrixtacy  , Sir please proceed and **CLOSE** issue #156 via this



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed internal Python path configuration that was no longer needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->