### PR TITLE
fix(cost-optimizer): add subtask content hash to cache key to prevent…

### DIFF
--- a/ai_council/orchestration/cost_optimizer.py
+++ b/ai_council/orchestration/cost_optimizer.py
@@ -479,13 +479,13 @@ class CostOptimizer:
         execution_mode: ExecutionMode, 
         available_models: List[str]
     ) -> str:
-        """Create a cache key for optimization results, including content hash."""
-        models_hash = hash(tuple(sorted(available_models)))
+        models_key = json.dumps(sorted(available_models), separators=(",", ":"))
+        models_hash = hashlib.sha256(models_key.encode("utf-8")).hexdigest()
         content = subtask.content
         if isinstance(content, (dict, list)):
             content_str = json.dumps(content, sort_keys=True)
         else:
-            content_str = str(content)     
+            content_str = str(content)  
         content_hash = hashlib.sha256(content_str.encode('utf-8')).hexdigest()
         return f"{subtask.task_type}_{execution_mode.value}_{subtask.priority.value}_{subtask.risk_level.value}_{models_hash}_{content_hash}"
     


### PR DESCRIPTION
# Fix: Prevent Cost Optimizer Cache Collisions

## Description
Fixed a bug in `CostOptimizer` where queries with identical metadata but different prompts incorrectly shared the same cache key. 

## Changes Made
- Updated `_create_cache_key` to include `subtask.content`.
- Implemented safe serialization for the prompt payload.
- Appended a SHA-256 hash of the content to the cache key to guarantee uniqueness without bloating cache size.

## Type of Change
- [x] Bug fix

## Testing
- [x] Verified locally: Tasks with identical execution parameters but different prompts now generate distinct cache keys.

Fixes #184 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved optimization cache stability with more deterministic key generation that properly accounts for model selections and content variations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->