### PR TITLE
fix(security): restrict default localhost CORS origins to development…

### DIFF
--- a/web_app/backend/main.py
+++ b/web_app/backend/main.py
@@ -95,7 +95,7 @@ else:
     load_dotenv()
 
 # CORS configuration
-env = os.getenv("ENVIRONMENT", "production").lower()
+env = os.getenv("ENVIRONMENT", "production").strip().lower()
 allowed_origins_str = os.getenv("ALLOWED_ORIGINS", "")
 if allowed_origins_str:
     allowed_origins = [origin.strip() for origin in allowed_origins_str.split(",") if origin.strip()]


### PR DESCRIPTION
## Description
Restricts the fallback `localhost` CORS origins to the `development` environment only. In production, missing origins now safely default to an empty list `[]` to prevent unauthorized access.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues
Fixes #183

## Changes Made
- Added `ENVIRONMENT` variable check.
- Isolated default `localhost` origins to `development` mode.
- Set production default fallback to `[]`.

## Testing
- [x] I have tested this change manually

## Testing Details
Verified CORS headers locally using `curl`:
- **Dev mode:** returns `access-control-allow-origin: http://localhost:3000`
- **Prod mode:** returns no CORS header (securely blocked).

## Code Quality
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code

## Screenshots
**Dev Mode (Localhost Allowed):**
**Production Mode (Blocked):**

## Screenshots 
**Development Mode (Localhost Allowed):**
<img width="1003" height="179" alt="Screenshot 2026-03-21 013047" src="https://github.com/user-attachments/assets/825c6ac3-2220-4b02-933e-8b231cd82081" />

**Production Mode (Fails Securely):**
<img width="1137" height="319" alt="Screenshot 2026-03-21 013038" src="https://github.com/user-attachments/assets/591b8e45-0e27-4743-905c-eaaa80de00d2" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Environment-driven CORS behavior: production now enforces stricter allowed-origins (no implicit localhost fallback), while development retains local-origin access when appropriate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->