### PR TITLE
fix(agent): use regex boundaries for confidence and assumption logic

### DIFF
--- a/ai_council/execution/agent.py
+++ b/ai_council/execution/agent.py
@@ -639,7 +639,8 @@ class BaseExecutionAgent(ExecutionAgent):
         # Use regex word boundaries and strictly self-referential phrases
         uncertainty_patterns = [
             r"\bi'm not sure\b", r"\bi am not sure\b", 
-            r"\bi think\b", r"\bi don't know\b", r"\bi do not know\b",
+            r"\bi think\s+(?:but|though|however|but i'm not sure|though i'm not sure)\b", 
+            r"\bi don't know\b", r"\bi do not know\b",
             r"\bit is unclear to me\b", r"\bi am uncertain\b", r"\bi'm uncertain\b",
             r"\bi am not confident\b", r"\bi'm not confident\b"
         ]
@@ -708,8 +709,9 @@ class BaseExecutionAgent(ExecutionAgent):
             r"\bpresuming\b", r"\btaking for granted\b", r"\bbased on the assumption\b"
         ]
         
-        # Split by periods, exclamation marks, question marks, or newlines
-        sentences = re.split(r'[.!?\n]+', response)
+        # Split by punctuation or newlines, but use negative lookbehinds to protect 
+        split_pattern = r'(?<!\d)(?<!\bDr)(?<!\bMr)(?<!\bMs)(?<!\bvs)(?<!\be\.g)(?<!\bi\.e)(?<!\bMrs)(?<!\betc)[.!?]+(?:\s+|\n+)|\n+'
+        sentences = re.split(split_pattern, response)
         
         for sentence in sentences:
             sentence_lower = sentence.lower().strip()


### PR DESCRIPTION
### Description
Fixes logical bugs in `BaseExecutionAgent` where basic substring matching caused false positives in confidence scoring and assumption extraction.

**Fixes #179

### Changes Made
- **`_calculate_confidence`:** Replaced basic string matching with regex word boundaries (`\b`) and first-person phrases (e.g., `"it is unclear to me"`) to prevent penalizing the agent for external/user uncertainty.
- **`_extract_assumptions`:** Added regex word boundaries to prevent extracting partial matches (e.g., `"unassuming"`). Improved sentence splitting with `re.split` and increased the length threshold to filter fragments.

### Testing
- [x] Tested locally via `test_agent_fixes.py` using `MagicMock`. 
- [x] Verified agent no longer penalizes itself for user uncertainty.
- [x] Verified partial words no longer trigger assumption extraction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved agent confidence scoring for more accurate confidence/uncertainty detection.
  * Enhanced assumption extraction with better sentence parsing and boundary handling.
  * Reduced false positives in detected assumptions through stricter matching and length filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->