### PR TITLE
fix(agent): derive model provider from metadata instead of ID substring

### DIFF
--- a/ai_council/execution/agent.py
+++ b/ai_council/execution/agent.py
@@ -430,9 +430,14 @@ class BaseExecutionAgent(ExecutionAgent):
         if hasattr(model, 'metadata') and isinstance(model.metadata, dict):
             provider = model.metadata.get("provider")
             if provider:
-                return str(provider).lower()
+                normalized = str(provider).strip().lower()
                 
-        # Fallback if metadata is missing or provider is not specified
+                # Verify the provider is actually configured in the rate limiter
+                configured_limits = getattr(rate_limit_manager, "rate_limits", {})
+                if normalized and normalized in configured_limits:
+                    return normalized
+                    
+        # Fallback if metadata is missing, provider is not specified, or unconfigured
         return "default"
     
     async def generate_self_assessment(self, response: str, subtask: Subtask, model_id: str) -> SelfAssessment:


### PR DESCRIPTION
### Description
Fixed `_get_model_provider` logic to use model metadata instead of fragile ID substring matching. This prevents misclassifying custom adapters (e.g., `my-custom-gpt-adapter`) as OpenAI.

**Fixes #182 

### Changes Made
- **Modified `_get_model_provider`:** Now pulls the provider name directly from `model.metadata` with a fallback to `"default"`.
- **Refined Regex:** Updated confidence and assumption logic with fixed-width negative lookbehinds to handle abbreviations and decimals correctly.
- **Accurate Counting:** Integrated `tiktoken` for precise token estimation.

### Testing
- [x] Verified via `test_agent_fixes.py`.
- [x] Confirmed `TEST 5` passes: custom metadata is prioritized over ID strings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal provider detection used for rate limiting by relying on model metadata instead of parsing model identifier strings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->