### PR TITLE
Fixes [BUG] JWT_SECRET_KEY Crash at Module Import Time #191

### DIFF
--- a/web_app/backend/main.py
+++ b/web_app/backend/main.py
@@ -10,7 +10,8 @@ import time
 from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import Any, Dict, List, Set
-
+JWT_SECRET_KEY = os.getenv("JWT_SECRET_KEY")
+JWT_ALGORITHM = os.getenv("JWT_ALGORITHM", "HS256")
 import jwt
 from dotenv import load_dotenv
 from fastapi import Depends, FastAPI, HTTPException, Request, WebSocket, WebSocketDisconnect
@@ -349,10 +350,6 @@ async def analyze_tradeoffs(request: Request, req: RequestModel, ai_council: AIC
     except Exception as exc:
         raise HTTPException(status_code=500, detail=str(exc)) from exc
 
-
-JWT_SECRET_KEY = os.getenv("JWT_SECRET_KEY")
-if not JWT_SECRET_KEY:
-    raise RuntimeError("JWT_SECRET_KEY must be set")
 JWT_ALGORITHM = os.getenv("JWT_ALGORITHM", "HS256")
 
 class WebSocketManager:
@@ -369,6 +366,10 @@ class WebSocketManager:
         self.RATE_LIMIT_WINDOW = 60  # seconds
 
     async def authenticate(self, websocket: WebSocket) -> bool:
+        jwt_secret = os.getenv("JWT_SECRET_KEY")
+        if not jwt_secret:
+            raise RuntimeError("JWT_SECRET_KEY must be set for WebSocket auth")
+        jwt_algorithm = JWT_ALGORITHM
         token = websocket.query_params.get("token")
         if not token:
             try:
@@ -381,7 +382,7 @@ class WebSocketManager:
             return False
             
         try:
-            jwt.decode(token, JWT_SECRET_KEY, algorithms=[JWT_ALGORITHM])
+            jwt.decode(token,jwt_secret, algorithms=[jwt_algorithm])
             return True
         except jwt.PyJWTError:
             return False


### PR DESCRIPTION
## FIXES #191 
---
## Description

The backend was previously crashing at import whenever JWT_SECRET_KEY was not set, even for scripts, tests, or endpoints that do not use WebSockets. This occurred because a top-level RuntimeError was raised in main.py during module load. As a result, developers and automated scripts could not run basic operations such as health checks or unit tests without defining the environment variable, which created unnecessary friction and reduced flexibility.

---

## Fix

To resolve this issue, the top-level check for JWT_SECRET_KEY was removed. Instead, JWT validation is now performed inside the WebSocketManager.authenticate method. This ensures that a RuntimeError is raised only when a WebSocket connection attempts authentication without the secret. Other backend functionality, including non-WebSocket endpoints, health checks, and test scripts, can now operate normally without requiring JWT_SECRET_KEY`.

---

## Impact

The backend no longer crashes at import or during test execution if JWT_SECRET_KEY is missing.
WebSocket connections still enforce JWT validation correctly, maintaining security for real-time features.
Development and testing workflows are more flexible and less error-prone, as missing JWT configuration no longer blocks non-WebSocket functionality.

---

## Changes

Updated main.py to remove the top-level JWT secret check.
Moved JWT validation logic into WebSocketManager.authenticate.
No new helper functions or utilities were introduced; the change is minimal and targeted.
Environment variable names (JWT_SECRET_KEY, JWT_ALGORITHM) remain unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WebSocket authentication error handling with more informative messages when required JWT configuration is missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->