### PR TITLE
fix: make model provider rate limits configurable

### DIFF
--- a/ai_council/execution/agent.py
+++ b/ai_council/execution/agent.py
@@ -51,13 +51,21 @@ class BaseExecutionAgent(ExecutionAgent):
             "model_api", api_cb_config
         )
         
-        rate_limits = {}
+        default_limits = {"openai": 60, "anthropic": 50, "default": 30}
 
-        if self.model_registry and hasattr(self.model_registry, "rate_limits"):
-            rate_limits = self.model_registry.rate_limits
-        rate_limit_manager.set_rate_limit("openai", rate_limits.get("openai", 60))
-        rate_limit_manager.set_rate_limit("anthropic", rate_limits.get("anthropic", 50))
-        rate_limit_manager.set_rate_limit("default", rate_limits.get("default", 30))
+        raw_limits = getattr(self.model_registry, "rate_limits", None) if self.model_registry else None
+        configured_limits = raw_limits if isinstance(raw_limits, dict) else {}
+
+        for provider, fallback in default_limits.items():
+            value = configured_limits.get(provider, fallback)
+            try:
+                rpm = int(value)
+                if rpm <= 0:
+                    rpm = fallback
+            except (TypeError, ValueError):
+                rpm = fallback
+
+            rate_limit_manager.set_rate_limit(provider, rpm)
 
     def _count_tokens(self, text: str) -> int:
         """Estimate tokens using simple logic (for tests)."""


### PR DESCRIPTION
# Pull Request

## Description
Replaced hardcoded model provider rate limits with a configurable approach using `model_registry`, while maintaining default fallback values for backward compatibility.

## Type of Change
- [x] Code refactoring

## Related Issues
Fixes #177

## Changes Made
- Removed hardcoded rate limits for model providers (`openai`, `anthropic`, `default`)
- Added support for configurable rate limits via `model_registry`
- Implemented safe fallback to default values when configuration is unavailable

## Testing
- [x] I have tested this change manually

## Testing Details
```python
class MockRegistry:
    rate_limits = {
        "openai": 10,
        "anthropic": 20,
        "default": 5
    }

agent = BaseExecutionAgent(model_registry=MockRegistry())
print(rate_limit_manager.rate_limits)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Rate-limit initialization now reads configuration dynamically from the model registry when available, with robust fallback handling for missing, non-numeric, or invalid values. This improves flexibility and reliability of request throttling across deployments while preserving previous behavior when registry data is absent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->