### PR TITLE
Implement manifest-based plugin system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -176,6 +176,8 @@ logs/
 *.log
 plugins/*
 !plugins/.gitkeep
+!plugins/example_plugin/
+!plugins/example_plugin/**
 demo_config.yaml
 *_example.py
 usage_example.py

--- a/ai_council/factory.py
+++ b/ai_council/factory.py
@@ -6,7 +6,7 @@ AI Council components based on the provided configuration.
 """
 
 from ai_council.core.logger import get_logger
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Any
 
 from .core.interfaces import (
     OrchestrationLayer, AnalysisEngine, TaskDecomposer, ModelContextProtocol,
@@ -158,10 +158,13 @@ class AICouncilFactory:
             self._synthesis_layer = self._create_synthesis_layer()
         return self._synthesis_layer
     
-    def create_orchestration_layer(self) -> OrchestrationLayer:
+    def create_orchestration_layer(self, plugin_context: Optional[Any] = None) -> OrchestrationLayer:
         """
         Create the main orchestration layer with all dependencies.
         
+        Args:
+            plugin_context: Optional plugin context for runtime hook registration
+
         Returns:
             OrchestrationLayer: Fully configured orchestration layer
         """
@@ -177,7 +180,8 @@ class AICouncilFactory:
             synthesis_layer=self.synthesis_layer,
             model_registry=self.model_registry,
             max_retries=self.config.execution.max_retries,
-            timeout_seconds=self.config.execution.default_timeout_seconds
+            timeout_seconds=self.config.execution.default_timeout_seconds,
+            plugin_context=plugin_context
         )
         
         self.logger.info("Orchestration layer created successfully")

--- a/ai_council/factory.py
+++ b/ai_council/factory.py
@@ -5,8 +5,7 @@ This module provides a factory class that creates and configures all
 AI Council components based on the provided configuration.
 """
 
-from ai_council.core.logger import get_logger
-from typing import Dict, List, Optional, Any
+from typing import Any, Dict, List, Optional
 
 from .core.interfaces import (
     OrchestrationLayer, AnalysisEngine, TaskDecomposer, ModelContextProtocol,

--- a/ai_council/main.py
+++ b/ai_council/main.py
@@ -18,6 +18,7 @@ from .core.error_handling import create_error_response
 from .core.interfaces import OrchestrationLayer
 from .utils.config import AICouncilConfig, load_config
 from .utils.logging import configure_logging, get_logger
+from .utils.plugin_manager import create_plugin_manager
 from .factory import AICouncilFactory
 from .sanitization import SanitizationFilter
 
@@ -65,8 +66,14 @@ class AICouncil:
         # This replaces the previous approach of importing and mutating the module-level global.
         _ = self.factory.adaptive_timeout_manager
         
-        # Initialize orchestration layer
-        self.orchestration_layer: OrchestrationLayer = self.factory.create_orchestration_layer()
+        # Initialize plugin manager and plugin context
+        self.plugin_manager = create_plugin_manager(self.config)
+        self.logger.info("Plugin manager initialized", extra={"plugin_count": len(self.plugin_manager.loaded_plugins)})
+
+        # Initialize orchestration layer with plugin hook support
+        self.orchestration_layer: OrchestrationLayer = self.factory.create_orchestration_layer(
+            plugin_context=self.plugin_manager.plugin_context
+        )
 
         # Initialize sanitization filter (runs before prompt construction)
         sanitization_config = (
@@ -172,6 +179,9 @@ class AICouncil:
                 error_type="prompt_injection",
             )
         # ─────────────────────────────────────────────────────────────────
+
+        if hasattr(self, 'plugin_manager') and self.plugin_manager.plugin_context:
+            self.plugin_manager.plugin_context.run_pre_execution_hooks(user_input, execution_mode)
 
         return await self._execute_with_timeout(user_input, execution_mode)
     

--- a/ai_council/main.py
+++ b/ai_council/main.py
@@ -7,7 +7,6 @@ components of the AI Council system and provides a simple interface
 for processing user requests.
 """
 
-from ai_council.core.logger import get_logger
 import sys
 import asyncio
 from pathlib import Path

--- a/ai_council/orchestration/layer.py
+++ b/ai_council/orchestration/layer.py
@@ -531,20 +531,20 @@ class ConcreteOrchestrationLayer(OrchestrationLayer):
         except Exception as e:
             logger.error("Request processing failed", extra={"error": str(e)})
             execution_time = time.time() - start_time
-            
+
             # Record system failure
-        failure_event = create_failure_event(
-            failure_type=FailureType.SYSTEM_OVERLOAD,
-            component="orchestration_layer",
-            error_message=str(e),
-            context={"execution_time": execution_time}
-        )
-        resilience_manager.handle_failure(failure_event)
-            
-        return create_error_response(
-            e,
-            context={'component': 'orchestration_layer.process_request'}
-        )
+            failure_event = create_failure_event(
+                failure_type=FailureType.SYSTEM_OVERLOAD,
+                component="orchestration_layer",
+                error_message=str(e),
+                context={"execution_time": execution_time}
+            )
+            resilience_manager.handle_failure(failure_event)
+
+            return create_error_response(
+                e,
+                context={'component': 'orchestration_layer.process_request'}
+            )
     
     # =========================================================================
     # PROTECTED METHODS - With circuit breaker protection

--- a/ai_council/orchestration/layer.py
+++ b/ai_council/orchestration/layer.py
@@ -288,7 +288,7 @@ class ConcreteOrchestrationLayer(OrchestrationLayer):
     async def _stage_arbitrate(self, responses: List[AgentResponse]):
 
         if len(responses) <= 1:
-            return responses, {
+            explanation = {
                 "selected_model": responses[0].model_used if responses else None,
                 "confidence": responses[0].self_assessment.confidence_score if responses and responses[0].self_assessment else 0.5,
                 "reason": "Only one model response available",
@@ -296,6 +296,7 @@ class ConcreteOrchestrationLayer(OrchestrationLayer):
                 "similarity_score": 1.0,
                 "conflict_detected": False
             }
+            return responses, explanation, []
 
         try:
             # ✅ 1. Collect model data

--- a/ai_council/orchestration/layer.py
+++ b/ai_council/orchestration/layer.py
@@ -60,7 +60,8 @@ class ConcreteOrchestrationLayer(OrchestrationLayer):
         synthesis_layer: SynthesisLayer,
         model_registry: ModelRegistry,
         max_retries: int = 3,
-        timeout_seconds: float = 300.0
+        timeout_seconds: float = 300.0,
+        plugin_context: Optional[Any] = None
     ):
         """
         Initialize the orchestration layer with all required components.
@@ -75,6 +76,7 @@ class ConcreteOrchestrationLayer(OrchestrationLayer):
             model_registry: Registry of available AI models
             max_retries: Maximum retry attempts for failed operations
             timeout_seconds: Maximum time allowed for request processing
+            plugin_context: Optional plugin context for runtime hooks
         """
         self.analysis_engine = analysis_engine
         self.task_decomposer = task_decomposer
@@ -85,6 +87,7 @@ class ConcreteOrchestrationLayer(OrchestrationLayer):
         self.model_registry = model_registry
         self.max_retries = max_retries
         self.timeout_seconds = timeout_seconds
+        self.plugin_context = plugin_context
         
         # Initialize cost optimizer
         self.cost_optimizer = CostOptimizer(model_registry)
@@ -482,7 +485,7 @@ class ConcreteOrchestrationLayer(OrchestrationLayer):
             
             # Stage 6: Arbitration
             try:
-                validated_responses, explanation,arbitration_decisions = await self._stage_arbitrate(successful_responses)
+                validated_responses, explanation, arbitration_decisions = await self._stage_arbitrate(successful_responses)
 
             except Exception as e:
                 logger.warning("Arbitration unpacking failed", extra={"error": str(e)})
@@ -490,11 +493,17 @@ class ConcreteOrchestrationLayer(OrchestrationLayer):
                 explanation = None
             
             execution_metadata.execution_path.append("arbitration")
+
+            if self.plugin_context:
+                self.plugin_context.run_post_arbitration_hooks(validated_responses, explanation)
             
             # Stage 7: Synthesis
             final_response = await self._stage_synthesize(validated_responses)
             final_response.explanation = explanation
             final_response.arbitration_decisions = arbitration_decisions
+
+            if self.plugin_context:
+                self.plugin_context.run_post_synthesis_hooks(final_response)
             execution_metadata.execution_path.append("synthesis")
             
             # Stage 8: Attach Metadata

--- a/ai_council/orchestration/layer.py
+++ b/ai_council/orchestration/layer.py
@@ -491,6 +491,7 @@ class ConcreteOrchestrationLayer(OrchestrationLayer):
                 logger.warning("Arbitration unpacking failed", extra={"error": str(e)})
                 validated_responses = successful_responses[:1]
                 explanation = None
+                arbitration_decisions = []
             
             execution_metadata.execution_path.append("arbitration")
 

--- a/ai_council/utils/config.py
+++ b/ai_council/utils/config.py
@@ -33,10 +33,14 @@ class PluginConfig:
     name: str = ""
     module_path: str = ""
     class_name: str = ""
+    entry_point: str = ""
     enabled: bool = True
     config: Dict[str, Any] = field(default_factory=dict)
     dependencies: List[str] = field(default_factory=list)
     version: str = "1.0.0"
+    description: str = ""
+    hooks: Dict[str, str] = field(default_factory=dict)
+    routing_rules: List[Dict[str, Any]] = field(default_factory=list)
 
 
 @dataclass
@@ -368,10 +372,14 @@ class AICouncilConfig:
                 name: {
                     'module_path': config.module_path,
                     'class_name': config.class_name,
+                    'entry_point': config.entry_point,
                     'enabled': config.enabled,
                     'config': config.config,
                     'dependencies': config.dependencies,
                     'version': config.version,
+                    'description': config.description,
+                    'hooks': config.hooks,
+                    'routing_rules': config.routing_rules,
                 }
                 for name, config in self.plugins.items()
             },
@@ -568,11 +576,15 @@ class AICouncilConfig:
         
         # Validate plugin configs
         for plugin_name, plugin_config in self.plugins.items():
-            if not plugin_config.module_path:
-                raise ValueError(f"Plugin {plugin_name}: module_path is required")
+            if not plugin_config.entry_point and not plugin_config.module_path:
+                raise ValueError(f"Plugin {plugin_name}: either module_path/class_name or entry_point is required")
             
-            if not plugin_config.class_name:
-                raise ValueError(f"Plugin {plugin_name}: class_name is required")
+            if plugin_config.module_path and not plugin_config.class_name:
+                raise ValueError(f"Plugin {plugin_name}: class_name is required when using module_path")
+            
+            if plugin_config.entry_point and plugin_config.module_path:
+                # Both styles are allowed, but entry_point takes precedence when present.
+                pass
         
         # Validate directories exist or can be created
         for dir_path in [self.data_dir, self.cache_dir, self.plugin_dir]:

--- a/ai_council/utils/plugin_manager.py
+++ b/ai_council/utils/plugin_manager.py
@@ -3,14 +3,17 @@
 import importlib
 import importlib.util
 import inspect
+import json
 import sys
 from pathlib import Path
-from typing import Dict, List, Type, Any, Optional, Callable
+from typing import Dict, List, Tuple, Type, Any, Optional, Callable
+import yaml
 from ai_council.core.logger import get_logger
 
 from ..core.interfaces import AIModel, AnalysisEngine, TaskDecomposer, ExecutionAgent
 from ..core.interfaces import ArbitrationLayer, SynthesisLayer, ModelRegistry
-from .config import PluginConfig, AICouncilConfig
+from ..core.models import ExecutionMode
+from .config import PluginConfig, AICouncilConfig, RoutingRule
 
 logger = get_logger(__name__)
 
@@ -18,6 +21,57 @@ logger = get_logger(__name__)
 class PluginError(Exception):
     """Exception raised when plugin operations fail."""
     pass
+
+
+class PluginContext:
+    """Registry for plugin runtime hooks and routing rules."""
+
+    def __init__(self, config: AICouncilConfig, manager: "PluginManager"):
+        self.config = config
+        self.manager = manager
+        self.pre_execution_hooks: List[Callable[[str, ExecutionMode], Any]] = []
+        self.post_arbitration_hooks: List[Callable[[List[Any], Any], Any]] = []
+        self.post_synthesis_hooks: List[Callable[[Any], Any]] = []
+        self.routing_rules: List[RoutingRule] = []
+
+    def register_pre_execution_hook(self, hook: Callable[[str, ExecutionMode], Any]) -> None:
+        self.pre_execution_hooks.append(hook)
+
+    def register_post_arbitration_hook(self, hook: Callable[[List[Any], Any], Any]) -> None:
+        self.post_arbitration_hooks.append(hook)
+
+    def register_post_synthesis_hook(self, hook: Callable[[Any], Any]) -> None:
+        self.post_synthesis_hooks.append(hook)
+
+    def register_routing_rule(self, rule: Any) -> None:
+        if isinstance(rule, dict):
+            rule = RoutingRule(**rule)
+        if not isinstance(rule, RoutingRule):
+            raise PluginError("Routing rule must be a RoutingRule or dict")
+
+        self.config.add_routing_rule(rule)
+        self.routing_rules.append(rule)
+
+    def run_pre_execution_hooks(self, user_input: str, execution_mode: ExecutionMode) -> None:
+        for hook in self.pre_execution_hooks:
+            try:
+                hook(user_input, execution_mode)
+            except Exception as e:
+                logger.warning("Plugin pre-execution hook failed", extra={"error": str(e)})
+
+    def run_post_arbitration_hooks(self, validated_responses: List[Any], explanation: Any) -> None:
+        for hook in self.post_arbitration_hooks:
+            try:
+                hook(validated_responses, explanation)
+            except Exception as e:
+                logger.warning("Plugin post-arbitration hook failed", extra={"error": str(e)})
+
+    def run_post_synthesis_hooks(self, final_response: Any) -> None:
+        for hook in self.post_synthesis_hooks:
+            try:
+                hook(final_response)
+            except Exception as e:
+                logger.warning("Plugin post-synthesis hook failed", extra={"error": str(e)})
 
 
 class PluginManager:
@@ -33,6 +87,8 @@ class PluginManager:
         self.loaded_plugins: Dict[str, Any] = {}
         self.plugin_instances: Dict[str, Any] = {}
         self.plugin_types: Dict[str, Type] = {}
+        self.manifest_plugins: Dict[str, Dict[str, Any]] = {}
+        self.plugin_context = PluginContext(config, self)
         
         # Supported plugin interfaces
         self.supported_interfaces = {
@@ -46,7 +102,8 @@ class PluginManager:
         }
     
     def load_all_plugins(self) -> None:
-        """Load all enabled plugins from configuration."""
+        """Load all enabled plugins from configuration and discover manifest-based plugins."""
+        # Load explicit plugin definitions from config first.
         for plugin_name, plugin_config in self.config.plugins.items():
             if plugin_config.enabled:
                 try:
@@ -55,16 +112,26 @@ class PluginManager:
                     logger.error("Failed to load plugin", extra={"plugin_name": plugin_name, "error": str(e)})
                     if self.config.debug:
                         raise
+
+        # Discover and load manifest-based plugins from the plugin directory.
+        for plugin_folder, manifest_data in self.discover_plugin_manifests():
+            try:
+                self.load_manifest_plugin(plugin_folder, manifest_data)
+            except Exception as e:
+                logger.error("Failed to load manifest plugin", extra={"plugin_folder": str(plugin_folder), "error": str(e)})
+                if self.config.debug:
+                    raise
     
-    def load_plugin(self, plugin_name: str, plugin_config: PluginConfig) -> Any:
+    def load_plugin(self, plugin_name: str, plugin_config: PluginConfig, plugin_base_path: Optional[Path] = None) -> Any:
         """Load a specific plugin.
         
         Args:
             plugin_name: Name of the plugin
             plugin_config: Configuration for the plugin
+            plugin_base_path: Optional path used to resolve entry points
             
         Returns:
-            The loaded plugin class
+            The loaded plugin class or registered plugin object
             
         Raises:
             PluginError: If plugin loading fails
@@ -72,26 +139,27 @@ class PluginManager:
         try:
             # Check dependencies
             self._check_dependencies(plugin_config.dependencies)
-            
-            # Import the plugin module
+
+            if plugin_config.entry_point:
+                # Load entry point style plugins that register hooks/context
+                base_path = plugin_base_path or Path(self.config.plugin_dir)
+                entry_callable = self._get_entry_point_callable(plugin_config.entry_point, base_path)
+                plugin_obj = entry_callable(self.plugin_context)
+                self.loaded_plugins[plugin_name] = plugin_obj or entry_callable
+                logger.info("Successfully loaded plugin entry point", extra={"plugin_name": plugin_name})
+                return plugin_obj
+
+            # Preserve existing module/class plugin loading behavior
             module = importlib.import_module(plugin_config.module_path)
-            
-            # Get the plugin class
             if not hasattr(module, plugin_config.class_name):
                 raise PluginError(f"Class {plugin_config.class_name} not found in module {plugin_config.module_path}")
-            
             plugin_class = getattr(module, plugin_config.class_name)
-            
-            # Validate plugin interface
             interface_type = self._validate_plugin_interface(plugin_class)
-            
-            # Store plugin information
             self.loaded_plugins[plugin_name] = plugin_class
             self.plugin_types[plugin_name] = interface_type
-            
             logger.info("Successfully loaded plugin", extra={"plugin_name": plugin_name, "interface_type": interface_type.__name__})
             return plugin_class
-            
+
         except Exception as e:
             raise PluginError(f"Failed to load plugin {plugin_name}: {e}")
     
@@ -274,16 +342,150 @@ class PluginManager:
         
         self.config.add_plugin(plugin_config)
         return plugin_name
-    
+
+    def discover_plugin_manifests(self, plugin_dir: Optional[str] = None) -> List[Tuple[Path, Dict[str, Any]]]:
+        """Discover plugin manifest files under the plugin directory."""
+        if plugin_dir is None:
+            plugin_dir = self.config.plugin_dir
+
+        plugin_path = Path(plugin_dir)
+        if not plugin_path.exists():
+            return []
+
+        manifests = []
+        for plugin_folder in plugin_path.iterdir():
+            if not plugin_folder.is_dir():
+                continue
+
+            manifest_path = None
+            for candidate in (plugin_folder / 'plugin.yaml', plugin_folder / 'plugin.yml', plugin_folder / 'plugin.json'):
+                if candidate.exists():
+                    manifest_path = candidate
+                    break
+
+            if manifest_path is None:
+                continue
+
+            manifest_data = self._load_manifest_file(manifest_path)
+            if manifest_data:
+                manifests.append((plugin_folder, manifest_data))
+
+        return manifests
+
+    def load_manifest_plugin(self, plugin_folder: Path, manifest_data: Dict[str, Any]) -> None:
+        """Load a plugin from a manifest file."""
+        self._validate_manifest_data(manifest_data)
+
+        plugin_name = manifest_data['name']
+        if plugin_name in self.config.plugins:
+            logger.warning("Manifest plugin skipped because config plugin already exists", extra={"plugin_name": plugin_name})
+            return
+
+        if not manifest_data.get('enabled', True):
+            logger.info("Manifest plugin disabled", extra={"plugin_name": plugin_name})
+            return
+
+        plugin_config = PluginConfig(
+            name=plugin_name,
+            entry_point=manifest_data['entry_point'],
+            enabled=manifest_data.get('enabled', True),
+            config=manifest_data.get('config', {}),
+            dependencies=manifest_data.get('dependencies', []),
+            version=manifest_data.get('version', '1.0.0'),
+            description=manifest_data.get('description', ''),
+            hooks=manifest_data.get('hooks', {}),
+            routing_rules=manifest_data.get('routing_rules', []),
+        )
+
+        self.config.add_plugin(plugin_config)
+        self.manifest_plugins[plugin_name] = manifest_data
+
+        # Register routing rules from manifest
+        for routing_rule in manifest_data.get('routing_rules', []):
+            try:
+                self.plugin_context.register_routing_rule(routing_rule)
+            except Exception as e:
+                logger.warning("Could not register manifest routing rule", extra={"plugin_name": plugin_name, "error": str(e)})
+
+        # Load the plugin entry point and call its register() function
+        self.load_plugin(plugin_name, plugin_config, plugin_folder)
+
+        # Register any hooks defined in the manifest directly
+        for hook_name, hook_entry in manifest_data.get('hooks', {}).items():
+            try:
+                hook_callable = self._get_entry_point_callable(hook_entry, plugin_folder)
+                self._register_hook(hook_name, hook_callable)
+            except Exception as e:
+                logger.warning("Could not load manifest hook", extra={"plugin_name": plugin_name, "hook": hook_name, "error": str(e)})
+
+    def _load_manifest_file(self, manifest_path: Path) -> Optional[Dict[str, Any]]:
+        try:
+            if manifest_path.suffix.lower() == '.json':
+                with open(manifest_path, 'r', encoding='utf-8') as f:
+                    return json.load(f)
+            with open(manifest_path, 'r', encoding='utf-8') as f:
+                return yaml.safe_load(f)
+        except Exception as e:
+            logger.warning("Failed to parse plugin manifest", extra={"manifest_path": str(manifest_path), "error": str(e)})
+            return None
+
+    def _validate_manifest_data(self, manifest_data: Dict[str, Any]) -> None:
+        missing_fields = [field for field in ('name', 'version', 'entry_point') if field not in manifest_data or not manifest_data[field]]
+        if missing_fields:
+            raise PluginError(f"Plugin manifest missing required fields: {', '.join(missing_fields)}")
+
+    def _get_entry_point_callable(self, entry_point: str, plugin_folder: Path) -> Callable:
+        if ':' in entry_point:
+            module_name, attr_name = entry_point.split(':', 1)
+        elif '.' in entry_point:
+            module_name, attr_name = entry_point.rsplit('.', 1)
+        else:
+            module_name, attr_name = entry_point, 'register'
+
+        try:
+            module = importlib.import_module(module_name)
+        except ImportError:
+            # Support both plugin folder and plugin root inputs.
+            candidate_roots = [plugin_folder]
+            if plugin_folder.parent not in candidate_roots:
+                candidate_roots.append(plugin_folder.parent)
+
+            imported = False
+            last_error: Optional[Exception] = None
+            for root in candidate_roots:
+                root_str = str(root)
+                if root_str not in sys.path:
+                    sys.path.insert(0, root_str)
+                try:
+                    module = importlib.import_module(module_name)
+                    imported = True
+                    break
+                except ImportError as e:
+                    last_error = e
+
+            if not imported:
+                raise PluginError(f"Could not import module for entry point {entry_point}: {last_error}")
+
+        if not hasattr(module, attr_name):
+            raise PluginError(f"Entry point {attr_name} not found in module {module_name}")
+
+        hook_callable = getattr(module, attr_name)
+        if not callable(hook_callable):
+            raise PluginError(f"Entry point {entry_point} is not callable")
+        return hook_callable
+
+    def _register_hook(self, hook_name: str, hook_callable: Callable) -> None:
+        if hook_name == 'pre_execution':
+            self.plugin_context.register_pre_execution_hook(hook_callable)
+        elif hook_name == 'post_arbitration':
+            self.plugin_context.register_post_arbitration_hook(hook_callable)
+        elif hook_name == 'post_synthesis':
+            self.plugin_context.register_post_synthesis_hook(hook_callable)
+        else:
+            raise PluginError(f"Unsupported hook name: {hook_name}")
+
     def _check_dependencies(self, dependencies: List[str]) -> None:
-        """Check if plugin dependencies are satisfied.
-        
-        Args:
-            dependencies: List of required dependencies
-            
-        Raises:
-            PluginError: If dependencies are not satisfied
-        """
+        """Check if plugin dependencies are satisfied."""
         for dependency in dependencies:
             try:
                 importlib.import_module(dependency)

--- a/ai_council/utils/plugin_manager.py
+++ b/ai_council/utils/plugin_manager.py
@@ -4,6 +4,7 @@ import importlib
 import importlib.util
 import inspect
 import json
+import sys
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Tuple, Type
 
@@ -104,7 +105,16 @@ class PluginManager:
     
     def load_all_plugins(self) -> None:
         """Load all enabled plugins from configuration and discover manifest-based plugins."""
-        # Load explicit plugin definitions from config first.
+        # Discover and merge manifest-based plugins first, before loading config plugins.
+        for plugin_folder, manifest_data in self.discover_plugin_manifests():
+            try:
+                self.load_manifest_plugin(plugin_folder, manifest_data)
+            except Exception as e:
+                logger.error("Failed to load manifest plugin", extra={"plugin_folder": str(plugin_folder), "error": str(e)})
+                if self.config.debug:
+                    raise
+
+        # Load explicit plugin definitions from config.
         for plugin_name, plugin_config in self.config.plugins.items():
             if plugin_config.enabled:
                 try:
@@ -113,15 +123,6 @@ class PluginManager:
                     logger.error("Failed to load plugin", extra={"plugin_name": plugin_name, "error": str(e)})
                     if self.config.debug:
                         raise
-
-        # Discover and load manifest-based plugins from the plugin directory.
-        for plugin_folder, manifest_data in self.discover_plugin_manifests():
-            try:
-                self.load_manifest_plugin(plugin_folder, manifest_data)
-            except Exception as e:
-                logger.error("Failed to load manifest plugin", extra={"plugin_folder": str(plugin_folder), "error": str(e)})
-                if self.config.debug:
-                    raise
     
     def load_plugin(self, plugin_name: str, plugin_config: PluginConfig, plugin_base_path: Optional[Path] = None) -> Any:
         """Load a specific plugin.
@@ -391,8 +392,13 @@ class PluginManager:
         self.config.add_plugin(plugin_config)
         self.manifest_plugins[plugin_name] = manifest_data
 
-        # Register routing rules from manifest
-        for routing_rule in manifest_data.get('routing_rules', []):
+        # Skip loading if plugin is disabled after merge
+        if not plugin_config.enabled:
+            logger.info("Manifest plugin disabled after merge", extra={"plugin_name": plugin_name})
+            return
+
+        # Register routing rules from plugin_config (post-merge source of truth)
+        for routing_rule in plugin_config.routing_rules:
             try:
                 self.plugin_context.register_routing_rule(routing_rule)
             except Exception as e:
@@ -401,8 +407,8 @@ class PluginManager:
         # Load the plugin entry point and call its register() function
         self.load_plugin(plugin_name, plugin_config, plugin_folder)
 
-        # Register any hooks defined in the manifest directly
-        for hook_name, hook_entry in manifest_data.get('hooks', {}).items():
+        # Register any hooks defined in plugin_config (post-merge source of truth)
+        for hook_name, hook_entry in plugin_config.hooks.items():
             try:
                 hook_callable = self._get_entry_point_callable(hook_entry, plugin_folder)
                 self._register_hook(hook_name, hook_callable)

--- a/ai_council/utils/plugin_manager.py
+++ b/ai_council/utils/plugin_manager.py
@@ -4,15 +4,16 @@ import importlib
 import importlib.util
 import inspect
 import json
-import sys
 from pathlib import Path
-from typing import Dict, List, Tuple, Type, Any, Optional, Callable
+from typing import Any, Callable, Dict, List, Optional, Tuple, Type
+
 import yaml
+
 from ai_council.core.logger import get_logger
 
 from ..core.interfaces import AIModel, AnalysisEngine, TaskDecomposer, ExecutionAgent
 from ..core.interfaces import ArbitrationLayer, SynthesisLayer, ModelRegistry
-from ..core.models import ExecutionMode
+from ..core.models import ExecutionMode, Priority, RiskLevel, TaskType
 from .config import PluginConfig, AICouncilConfig, RoutingRule
 
 logger = get_logger(__name__)
@@ -45,7 +46,7 @@ class PluginContext:
 
     def register_routing_rule(self, rule: Any) -> None:
         if isinstance(rule, dict):
-            rule = RoutingRule(**rule)
+            rule = self.manager._normalize_routing_rule_from_manifest(rule)
         if not isinstance(rule, RoutingRule):
             raise PluginError("Routing rule must be a RoutingRule or dict")
 
@@ -377,26 +378,16 @@ class PluginManager:
         self._validate_manifest_data(manifest_data)
 
         plugin_name = manifest_data['name']
-        if plugin_name in self.config.plugins:
-            logger.warning("Manifest plugin skipped because config plugin already exists", extra={"plugin_name": plugin_name})
-            return
-
-        if not manifest_data.get('enabled', True):
+        existing_plugin = self.config.plugins.get(plugin_name)
+        if existing_plugin is None and not manifest_data.get('enabled', True):
             logger.info("Manifest plugin disabled", extra={"plugin_name": plugin_name})
             return
 
-        plugin_config = PluginConfig(
-            name=plugin_name,
-            entry_point=manifest_data['entry_point'],
-            enabled=manifest_data.get('enabled', True),
-            config=manifest_data.get('config', {}),
-            dependencies=manifest_data.get('dependencies', []),
-            version=manifest_data.get('version', '1.0.0'),
-            description=manifest_data.get('description', ''),
-            hooks=manifest_data.get('hooks', {}),
-            routing_rules=manifest_data.get('routing_rules', []),
+        plugin_config = self._merge_manifest_into_plugin_config(
+            plugin_name=plugin_name,
+            manifest_data=manifest_data,
+            existing_plugin=existing_plugin,
         )
-
         self.config.add_plugin(plugin_config)
         self.manifest_plugins[plugin_name] = manifest_data
 
@@ -434,6 +425,87 @@ class PluginManager:
         if missing_fields:
             raise PluginError(f"Plugin manifest missing required fields: {', '.join(missing_fields)}")
 
+    def _merge_manifest_into_plugin_config(
+        self,
+        plugin_name: str,
+        manifest_data: Dict[str, Any],
+        existing_plugin: Optional[PluginConfig],
+    ) -> PluginConfig:
+        """Merge manifest metadata with existing config while preserving explicit config overrides."""
+        if existing_plugin is None:
+            return PluginConfig(
+                name=plugin_name,
+                entry_point=manifest_data['entry_point'],
+                enabled=manifest_data.get('enabled', True),
+                config=manifest_data.get('config', {}),
+                dependencies=manifest_data.get('dependencies', []),
+                version=manifest_data.get('version', '1.0.0'),
+                description=manifest_data.get('description', ''),
+                hooks=manifest_data.get('hooks', {}),
+                routing_rules=manifest_data.get('routing_rules', []),
+            )
+
+        merged_config = {
+            **manifest_data.get('config', {}),
+            **existing_plugin.config,
+        }
+        merged_dependencies = existing_plugin.dependencies or manifest_data.get('dependencies', [])
+        merged_hooks = {
+            **manifest_data.get('hooks', {}),
+            **existing_plugin.hooks,
+        }
+        merged_routing_rules = existing_plugin.routing_rules or manifest_data.get('routing_rules', [])
+
+        effective_entry_point = existing_plugin.entry_point
+        if not effective_entry_point and not existing_plugin.module_path:
+            effective_entry_point = manifest_data['entry_point']
+
+        return PluginConfig(
+            name=plugin_name,
+            module_path=existing_plugin.module_path,
+            class_name=existing_plugin.class_name,
+            entry_point=effective_entry_point,
+            enabled=existing_plugin.enabled,
+            config=merged_config,
+            dependencies=merged_dependencies,
+            version=existing_plugin.version or manifest_data.get('version', '1.0.0'),
+            description=existing_plugin.description or manifest_data.get('description', ''),
+            hooks=merged_hooks,
+            routing_rules=merged_routing_rules,
+        )
+
+    def _convert_enum_list(self, values: List[Any], enum_class: Type) -> List[Any]:
+        """Convert manifest string values to enum values when possible."""
+        converted: List[Any] = []
+        for value in values:
+            if not isinstance(value, str):
+                converted.append(value)
+                continue
+
+            candidates = [value, value.lower(), value.upper()]
+            converted_value = value
+            for candidate in candidates:
+                try:
+                    converted_value = enum_class(candidate)
+                    break
+                except ValueError:
+                    continue
+            converted.append(converted_value)
+        return converted
+
+    def _normalize_routing_rule_from_manifest(self, rule_data: Dict[str, Any]) -> RoutingRule:
+        """Normalize routing rule dictionary values for enum-backed fields."""
+        normalized = dict(rule_data)
+        if 'task_types' in normalized:
+            normalized['task_types'] = self._convert_enum_list(normalized['task_types'], TaskType)
+        if 'priority_levels' in normalized:
+            normalized['priority_levels'] = self._convert_enum_list(normalized['priority_levels'], Priority)
+        if 'risk_levels' in normalized:
+            normalized['risk_levels'] = self._convert_enum_list(normalized['risk_levels'], RiskLevel)
+        if 'execution_modes' in normalized:
+            normalized['execution_modes'] = self._convert_enum_list(normalized['execution_modes'], ExecutionMode)
+        return RoutingRule(**normalized)
+
     def _get_entry_point_callable(self, entry_point: str, plugin_folder: Path) -> Callable:
         if ':' in entry_point:
             module_name, attr_name = entry_point.split(':', 1)
@@ -445,26 +517,7 @@ class PluginManager:
         try:
             module = importlib.import_module(module_name)
         except ImportError:
-            # Support both plugin folder and plugin root inputs.
-            candidate_roots = [plugin_folder]
-            if plugin_folder.parent not in candidate_roots:
-                candidate_roots.append(plugin_folder.parent)
-
-            imported = False
-            last_error: Optional[Exception] = None
-            for root in candidate_roots:
-                root_str = str(root)
-                if root_str not in sys.path:
-                    sys.path.insert(0, root_str)
-                try:
-                    module = importlib.import_module(module_name)
-                    imported = True
-                    break
-                except ImportError as e:
-                    last_error = e
-
-            if not imported:
-                raise PluginError(f"Could not import module for entry point {entry_point}: {last_error}")
+            module = self._load_entry_point_module_from_path(module_name, plugin_folder)
 
         if not hasattr(module, attr_name):
             raise PluginError(f"Entry point {attr_name} not found in module {module_name}")
@@ -473,6 +526,28 @@ class PluginManager:
         if not callable(hook_callable):
             raise PluginError(f"Entry point {entry_point} is not callable")
         return hook_callable
+
+    def _load_entry_point_module_from_path(self, module_name: str, plugin_folder: Path):
+        """Load a plugin module from explicit plugin paths without mutating sys.path globally."""
+        module_parts = module_name.split('.')
+        candidate_files: List[Path] = []
+
+        if plugin_folder.name == module_parts[0] and len(module_parts) > 1:
+            candidate_files.append(plugin_folder.joinpath(*module_parts[1:]).with_suffix('.py'))
+        candidate_files.append(plugin_folder.joinpath(*module_parts).with_suffix('.py'))
+        candidate_files.append(plugin_folder.parent.joinpath(*module_parts).with_suffix('.py'))
+
+        for module_file in candidate_files:
+            if not module_file.exists():
+                continue
+            spec = importlib.util.spec_from_file_location(module_name, module_file)
+            if spec is None or spec.loader is None:
+                continue
+            module = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(module)
+            return module
+
+        raise PluginError(f"Could not import module for entry point {module_name} from plugin path {plugin_folder}")
 
     def _register_hook(self, hook_name: str, hook_callable: Callable) -> None:
         if hook_name == 'pre_execution':

--- a/docs/usage/plugin_system.md
+++ b/docs/usage/plugin_system.md
@@ -1,0 +1,104 @@
+# Plugin System
+
+AI Council supports a manifest-based plugin system that discovers plugin folders under the `plugins/` directory.
+
+## Plugin folder structure
+
+A manifest-based plugin lives in its own folder under `plugins/`.
+
+Example:
+
+```
+plugins/example_plugin/
+  plugin.py
+  plugin.yaml
+```
+
+The manifest can be either `plugin.yaml`, `plugin.yml`, or `plugin.json`.
+
+## Manifest fields
+
+Required fields:
+
+- `name`: Unique plugin name
+- `version`: Plugin version
+- `entry_point`: Python entry point for the plugin registration function
+
+Optional fields:
+
+- `description`: Free-form plugin description
+- `hooks`: Map hook names to entry points
+- `routing_rules`: List of routing rule definitions
+
+### Example `plugin.yaml`
+
+```yaml
+name: example-plugin
+version: "1.0.0"
+description: "Example manifest-based plugin for AI Council."
+entry_point: example_plugin.plugin:register
+hooks:
+  pre_execution: example_plugin.plugin:pre_execution
+  post_arbitration: example_plugin.plugin:post_arbitration
+  post_synthesis: example_plugin.plugin:post_synthesis
+routing_rules:
+  - name: example-plugin-cost-aware
+    task_types:
+      - reasoning
+    enabled: true
+    weight: 0.5
+```
+
+## `plugin.py` example
+
+The plugin module should expose a callable that can register hooks and routing rules using the plugin context.
+
+```python
+from ai_council.core.models import ExecutionMode
+
+
+def register(context):
+  # Hooks are declared in the manifest under `hooks`.
+  # Routing rules are declared in the manifest under `routing_rules`.
+  return None
+
+
+def pre_execution(user_input: str, execution_mode: ExecutionMode):
+    return None
+
+
+def post_arbitration(validated_responses, explanation):
+    return None
+
+
+def post_synthesis(final_response):
+    return None
+```
+
+## Hooks
+
+Supported hook names:
+
+- `pre_execution`
+- `post_arbitration`
+- `post_synthesis`
+
+Hooks may be registered by manifest field entries under `hooks`, and they are invoked at runtime by the orchestration layer.
+
+## Routing rules
+
+Plugins can add routing rules directly from the manifest under `routing_rules`.
+These rules are registered in the AI Council config and can influence model selection.
+
+## Usage
+
+AI Council automatically discovers manifest plugins during startup from `config.plugin_dir` (default `./plugins`).
+
+To use manifest-based plugins:
+
+1. Create a plugin folder under `plugins/`
+2. Add a manifest file (`plugin.yaml`, `plugin.yml`, or `plugin.json`)
+3. Add the plugin module and entry point file
+4. Start AI Council normally
+
+If you need to preserve existing configuration-based plugins, use `config.plugins` entries with `module_path`/`class_name` or `entry_point`.

--- a/docs/usage/plugin_system.md
+++ b/docs/usage/plugin_system.md
@@ -8,7 +8,7 @@ A manifest-based plugin lives in its own folder under `plugins/`.
 
 Example:
 
-```
+```text
 plugins/example_plugin/
   plugin.py
   plugin.yaml
@@ -27,6 +27,9 @@ Required fields:
 Optional fields:
 
 - `description`: Free-form plugin description
+- `enabled`: Enable/disable loading for a manifest plugin
+- `dependencies`: Python module dependencies checked before plugin load
+- `config`: Plugin-specific configuration dictionary
 - `hooks`: Map hook names to entry points
 - `routing_rules`: List of routing rule definitions
 

--- a/plugins/example_plugin/plugin.py
+++ b/plugins/example_plugin/plugin.py
@@ -1,0 +1,23 @@
+from ai_council.core.models import ExecutionMode
+
+
+def register(context):
+    """Register example plugin hooks."""
+    # Routing rules are declared through the manifest. Hooks are registered separately.
+    return None
+
+
+def pre_execution(user_input: str, execution_mode: ExecutionMode):
+    """Example pre-execution hook."""
+    # Plugins may inspect or log the request before orchestration begins.
+    return None
+
+
+def post_arbitration(validated_responses, explanation):
+    """Example post-arbitration hook."""
+    return None
+
+
+def post_synthesis(final_response):
+    """Example post-synthesis hook."""
+    return None

--- a/plugins/example_plugin/plugin.yaml
+++ b/plugins/example_plugin/plugin.yaml
@@ -1,0 +1,14 @@
+name: example-plugin
+version: "1.0.0"
+description: "Example manifest-based plugin for AI Council."
+entry_point: example_plugin.plugin:register
+hooks:
+  pre_execution: example_plugin.plugin:pre_execution
+  post_arbitration: example_plugin.plugin:post_arbitration
+  post_synthesis: example_plugin.plugin:post_synthesis
+routing_rules:
+  - name: example-plugin-cost-aware
+    task_types:
+      - reasoning
+    enabled: true
+    weight: 0.5

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -164,6 +164,20 @@ class TestPluginConfig:
         assert config.class_name == "CustomModelAdapter"
         assert "api_url" in config.config
 
+    def test_plugin_config_with_entry_point(self):
+        """Test PluginConfig with entry point registration."""
+        config = PluginConfig(
+            name="example-plugin",
+            entry_point="example_plugin.plugin:register",
+            enabled=True,
+            version="1.2.0",
+            description="Example entry point plugin",
+        )
+
+        assert config.entry_point == "example_plugin.plugin:register"
+        assert config.version == "1.2.0"
+        assert config.description == "Example entry point plugin"
+
 
 # =============================================================================
 # ExecutionModeConfig Tests

--- a/tests/test_plugin_manager.py
+++ b/tests/test_plugin_manager.py
@@ -1,16 +1,15 @@
-import os
-import tempfile
+import json
 from pathlib import Path
 
 import pytest
 import yaml
 
-from ai_council.core.logger import get_logger
+from ai_council.core.models import TaskType
 from ai_council.utils.config import AICouncilConfig, PluginConfig
 from ai_council.utils.plugin_manager import PluginError, PluginManager, create_plugin_manager
 
 
-def _write_example_plugin(plugin_dir: Path) -> None:
+def _write_example_plugin(plugin_dir: Path, manifest_file_name: str = "plugin.yaml") -> None:
     plugin_dir.mkdir(parents=True, exist_ok=True)
     plugin_code = """from ai_council.core.models import ExecutionMode
 
@@ -52,13 +51,21 @@ def post_synthesis(final_response):
             }
         ],
     }
-    (plugin_dir / "plugin.yaml").write_text(yaml.safe_dump(manifest), encoding="utf-8")
+    (plugin_dir / manifest_file_name).write_text(yaml.safe_dump(manifest), encoding="utf-8")
 
 
-def test_manifest_plugin_discovery_and_hook_registration(tmp_path: Path):
+@pytest.mark.parametrize("manifest_file_name", ["plugin.yaml", "plugin.yml", "plugin.json"])
+def test_manifest_plugin_discovery_and_hook_registration(tmp_path: Path, manifest_file_name: str):
     plugins_root = tmp_path / "plugins"
     plugin_dir = plugins_root / "example_plugin"
-    _write_example_plugin(plugin_dir)
+    _write_example_plugin(plugin_dir, manifest_file_name)
+
+    if manifest_file_name.endswith(".json"):
+        yaml_data = yaml.safe_load((plugin_dir / manifest_file_name).read_text(encoding="utf-8"))
+        (plugin_dir / manifest_file_name).write_text(
+            json.dumps(yaml_data),
+            encoding="utf-8",
+        )
 
     config = AICouncilConfig(plugin_dir=str(plugins_root))
     manager = create_plugin_manager(config)
@@ -69,6 +76,7 @@ def test_manifest_plugin_discovery_and_hook_registration(tmp_path: Path):
     assert len(manager.plugin_context.post_synthesis_hooks) == 1
     assert len(manager.plugin_context.routing_rules) == 1
     assert manager.plugin_context.routing_rules[0].name == "example-plugin-cost-aware"
+    assert manager.plugin_context.routing_rules[0].task_types[0] == TaskType.REASONING
 
 
 def test_manifest_plugin_validation_requires_entry_point(tmp_path: Path):
@@ -105,3 +113,28 @@ def test_config_entry_point_plugin_loads_from_plugin_dir(tmp_path: Path):
 
     manager = create_plugin_manager(config)
     assert "example-plugin" in manager.loaded_plugins
+
+
+def test_manifest_metadata_merges_with_existing_config_plugin(tmp_path: Path):
+    plugins_root = tmp_path / "plugins"
+    plugin_dir = plugins_root / "example_plugin"
+    _write_example_plugin(plugin_dir)
+
+    config = AICouncilConfig(
+        plugin_dir=str(plugins_root),
+        plugins={
+            "example-plugin": PluginConfig(
+                name="example-plugin",
+                config={"override": "from-config"},
+                enabled=True,
+            )
+        },
+    )
+
+    manager = create_plugin_manager(config)
+    merged = manager.config.plugins["example-plugin"]
+
+    assert merged.entry_point == "example_plugin.plugin:register"
+    assert merged.config["override"] == "from-config"
+    assert len(manager.plugin_context.pre_execution_hooks) == 1
+    assert len(manager.plugin_context.routing_rules) == 1

--- a/tests/test_plugin_manager.py
+++ b/tests/test_plugin_manager.py
@@ -1,0 +1,107 @@
+import os
+import tempfile
+from pathlib import Path
+
+import pytest
+import yaml
+
+from ai_council.core.logger import get_logger
+from ai_council.utils.config import AICouncilConfig, PluginConfig
+from ai_council.utils.plugin_manager import PluginError, PluginManager, create_plugin_manager
+
+
+def _write_example_plugin(plugin_dir: Path) -> None:
+    plugin_dir.mkdir(parents=True, exist_ok=True)
+    plugin_code = """from ai_council.core.models import ExecutionMode
+
+
+def register(context):
+    # The routing rule is declared through the manifest.
+    return None
+
+
+def pre_execution(user_input: str, execution_mode: ExecutionMode):
+    return None
+
+
+def post_arbitration(validated_responses, explanation):
+    return None
+
+
+def post_synthesis(final_response):
+    return None
+"""
+    (plugin_dir / "plugin.py").write_text(plugin_code, encoding="utf-8")
+
+    manifest = {
+        "name": "example-plugin",
+        "version": "1.0.0",
+        "description": "Example manifest-based plugin.",
+        "entry_point": "example_plugin.plugin:register",
+        "hooks": {
+            "pre_execution": "example_plugin.plugin:pre_execution",
+            "post_arbitration": "example_plugin.plugin:post_arbitration",
+            "post_synthesis": "example_plugin.plugin:post_synthesis",
+        },
+        "routing_rules": [
+            {
+                "name": "example-plugin-cost-aware",
+                "task_types": ["reasoning"],
+                "enabled": True,
+                "weight": 0.5,
+            }
+        ],
+    }
+    (plugin_dir / "plugin.yaml").write_text(yaml.safe_dump(manifest), encoding="utf-8")
+
+
+def test_manifest_plugin_discovery_and_hook_registration(tmp_path: Path):
+    plugins_root = tmp_path / "plugins"
+    plugin_dir = plugins_root / "example_plugin"
+    _write_example_plugin(plugin_dir)
+
+    config = AICouncilConfig(plugin_dir=str(plugins_root))
+    manager = create_plugin_manager(config)
+
+    assert "example-plugin" in manager.loaded_plugins
+    assert len(manager.plugin_context.pre_execution_hooks) == 1
+    assert len(manager.plugin_context.post_arbitration_hooks) == 1
+    assert len(manager.plugin_context.post_synthesis_hooks) == 1
+    assert len(manager.plugin_context.routing_rules) == 1
+    assert manager.plugin_context.routing_rules[0].name == "example-plugin-cost-aware"
+
+
+def test_manifest_plugin_validation_requires_entry_point(tmp_path: Path):
+    plugins_root = tmp_path / "plugins"
+    plugin_dir = plugins_root / "bad_plugin"
+    plugin_dir.mkdir(parents=True, exist_ok=True)
+    (plugin_dir / "plugin.yaml").write_text(
+        yaml.safe_dump({"name": "bad-plugin", "version": "1.0.0"}),
+        encoding="utf-8"
+    )
+
+    config = AICouncilConfig(plugin_dir=str(plugins_root))
+    manager = PluginManager(config)
+
+    with pytest.raises(PluginError, match="missing required fields"):
+        manager.load_manifest_plugin(plugin_dir, {"name": "bad-plugin", "version": "1.0.0"})
+
+
+def test_config_entry_point_plugin_loads_from_plugin_dir(tmp_path: Path):
+    plugins_root = tmp_path / "plugins"
+    plugin_dir = plugins_root / "example_plugin"
+    _write_example_plugin(plugin_dir)
+
+    config = AICouncilConfig(
+        plugin_dir=str(plugins_root),
+        plugins={
+            "example-plugin": PluginConfig(
+                name="example-plugin",
+                entry_point="example_plugin.plugin:register",
+                enabled=True,
+            )
+        },
+    )
+
+    manager = create_plugin_manager(config)
+    assert "example-plugin" in manager.loaded_plugins


### PR DESCRIPTION
# Pull Request

## Description
Implemented a manifest-based plugin system for AI Council so plugins can be added through manifests under the `plugins/` directory while preserving existing module-path based plugin loading.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Related Issues
Fixes #168

## Changes Made
- Added support for manifest-based plugins using `plugin.yaml`, `plugin.yml`, and `plugin.json`
- Added plugin discovery from the `plugins/` directory
- Added manifest validation for required fields:
  - `name`
  - `version`
  - `entry_point`
- Added support for optional manifest fields:
  - `description`
  - `hooks`
  - `routing_rules`
- Added dynamic plugin entry point loading through `register(context)`
- Preserved existing module-path/class-name plugin loading behavior
- Added extension hook support for:
  - `pre_execution`
  - `post_arbitration`
  - `post_synthesis`
- Added routing rule registration through plugin manifests/context
- Added an example plugin under `plugins/example_plugin`
- Added plugin system documentation
- Added plugin manager/config tests

## Testing
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this change manually

## Testing Details
```bash
python -m compileall ai_council plugins
pytest tests/test_plugin_manager.py tests/test_config.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a manifest-based plugin system with discovery, manifest loading, entry-point support, routing rules, and runtime hook registration; orchestration now runs plugin hooks at pre-execution, post-arbitration, and post-synthesis and attaches explanations/arbitration details to responses.
  * Included an example plugin and manifest demonstrating hooks and routing.

* **Documentation**
  * Added a comprehensive plugin system usage guide with examples.

* **Tests**
  * Expanded tests for manifest discovery, loading, merging metadata, and hook/routing registration.

* **Chores**
  * Example plugin directory is now tracked in the repository.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shrixtacy/Ai-Council/pull/244?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->